### PR TITLE
Raise test coverage to 100%

### DIFF
--- a/src/django_qstash/schedules/models.py
+++ b/src/django_qstash/schedules/models.py
@@ -99,7 +99,7 @@ class TaskSchedule(models.Model):
             self.resumed_at = None
             self.active_at = None
             self.is_active = False
-        elif self.is_active:
+        else:
             self.is_paused = False
             self.is_resumed = True
             self.paused_at = None

--- a/tests/app/test_shared_tasks.py
+++ b/tests/app/test_shared_tasks.py
@@ -4,8 +4,11 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ImproperlyConfigured
 
 from django_qstash.app import stashed_task
+from django_qstash.app.base import AsyncResult
+from django_qstash.app.base import QStashTask
 
 
 @stashed_task
@@ -16,6 +19,12 @@ def sample_task(x, y):
 @stashed_task(name="custom_task", deduplicated=True)
 def sample_task_with_options(x, y):
     return x * y
+
+
+class Calculator:
+    @stashed_task
+    def double(self, value):
+        return value * 2
 
 
 @pytest.fixture(autouse=True)
@@ -59,3 +68,63 @@ class TestQStashTasks:
         assert result.task_id == "test-id-123"
         call_kwargs = mock_qstash_client.message.publish_json.call_args[1]
         assert call_kwargs["delay"] == "60s"
+
+    def test_task_apply_async_without_countdown(self, mock_qstash_client):
+        """apply_async() without countdown still publishes to QStash."""
+        result = sample_task.apply_async(args=(2, 3))
+
+        assert result.task_id == "test-id-123"
+        mock_qstash_client.message.publish_json.assert_called_once()
+
+    def test_parameterized_decorator(self):
+        """stashed_task(name=...) returns a decorator that wraps the function."""
+        decorator = stashed_task(name="mytask")
+        assert callable(decorator)
+
+        def myfunc(a):
+            return a
+
+        wrapped = decorator(myfunc)
+        assert isinstance(wrapped, QStashTask)
+        assert wrapped.name == "mytask"
+        assert wrapped(5) == 5
+
+    def test_qstashtask_called_with_func_creates_wrapper(self):
+        """A QStashTask with no func, called with a function, wraps it."""
+        task = QStashTask(name="mytask")
+        assert task.func is None
+
+        def myfunc(a):
+            return a
+
+        wrapped = task(myfunc)
+        assert isinstance(wrapped, QStashTask)
+        assert wrapped.name == "mytask"
+        assert wrapped(7) == 7
+
+    def test_instance_method_access_and_call(self):
+        """Accessing a task on an instance binds it; calling runs it directly."""
+        calc = Calculator()
+        assert calc.double(4) == 8
+
+    def test_class_access_returns_task(self):
+        """Accessing a task on the class returns the QStashTask descriptor."""
+        assert isinstance(Calculator.double, QStashTask)
+
+    def test_missing_config_raises(self, monkeypatch):
+        """Missing QSTASH_TOKEN/DOMAIN raises ImproperlyConfigured on call."""
+        monkeypatch.setattr("django_qstash.app.base.QSTASH_TOKEN", "")
+        with pytest.raises(ImproperlyConfigured):
+            sample_task(2, 3)
+
+
+class TestAsyncResult:
+    def test_id_property(self):
+        result = AsyncResult("abc-123")
+        assert result.id == "abc-123"
+        assert result.task_id == "abc-123"
+
+    def test_get_not_implemented(self):
+        result = AsyncResult("abc-123")
+        with pytest.raises(NotImplementedError):
+            result.get()

--- a/tests/discovery/test_utils.py
+++ b/tests/discovery/test_utils.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import types
+
+import pytest
+
+from django_qstash.discovery import utils
 from django_qstash.discovery.utils import discover_tasks
 
 
@@ -38,3 +43,109 @@ def test_discovers_basic_task():
     tasks_set = {tuple(sorted(t.items())) for t in tasks}
     expected_tasks_set = {tuple(sorted(t.items())) for t in expected_tasks}
     assert tasks_set == expected_tasks_set
+
+
+def test_discovers_tasks_in_settings_dir(monkeypatch):
+    """Tasks living next to settings.py are discovered."""
+    from django_qstash.app import QStashTask
+
+    @QStashTask
+    def settings_task():
+        return "ok"
+
+    fake_module = types.ModuleType("tests.tasks")
+    fake_module.settings_task = settings_task
+
+    orig_import = utils.import_module
+    orig_has = utils.module_has_submodule
+
+    def fake_import(name):
+        if name == "tests.tasks":
+            return fake_module
+        return orig_import(name)
+
+    def fake_has(module, submodule):
+        if submodule == "tasks" and getattr(module, "__name__", "") == "tests":
+            return True
+        return orig_has(module, submodule)
+
+    monkeypatch.setattr(utils, "import_module", fake_import)
+    monkeypatch.setattr(utils, "module_has_submodule", fake_has)
+    monkeypatch.setattr(utils, "DJANGO_QSTASH_DISCOVER_INCLUDE_SETTINGS_DIR", True)
+
+    utils._discover_tasks_impl.cache_clear()
+    try:
+        locations = discover_tasks(locations_only=True)
+        assert "tests.tasks.settings_task" in locations
+    finally:
+        utils._discover_tasks_impl.cache_clear()
+
+
+def test_settings_dir_discovery_disabled(monkeypatch):
+    """When the settings-dir opt-in is off, the settings package is skipped."""
+    monkeypatch.setattr(utils, "DJANGO_QSTASH_DISCOVER_INCLUDE_SETTINGS_DIR", False)
+
+    calls = []
+    orig_import = utils.import_module
+
+    def tracking_import(name):
+        calls.append(name)
+        return orig_import(name)
+
+    monkeypatch.setattr(utils, "import_module", tracking_import)
+    utils._discover_tasks_impl.cache_clear()
+    try:
+        discover_tasks()
+        assert "tests" not in calls
+    finally:
+        utils._discover_tasks_impl.cache_clear()
+
+
+def test_settings_dir_discovery_no_settings_module(monkeypatch):
+    """With no DJANGO_SETTINGS_MODULE set, settings-dir discovery is skipped."""
+    monkeypatch.setattr(utils, "DJANGO_QSTASH_DISCOVER_INCLUDE_SETTINGS_DIR", True)
+    monkeypatch.setattr(utils.os.environ, "get", lambda *a, **k: "")
+
+    utils._discover_tasks_impl.cache_clear()
+    try:
+        discover_tasks()  # should not raise
+    finally:
+        utils._discover_tasks_impl.cache_clear()
+
+
+def test_settings_package_import_failure_warns(monkeypatch):
+    """A settings package that can't be imported warns but doesn't crash."""
+    orig_import = utils.import_module
+
+    def fake_import(name):
+        if name == "tests":
+            raise ImportError("no settings package")
+        return orig_import(name)
+
+    monkeypatch.setattr(utils, "import_module", fake_import)
+    monkeypatch.setattr(utils, "DJANGO_QSTASH_DISCOVER_INCLUDE_SETTINGS_DIR", True)
+    utils._discover_tasks_impl.cache_clear()
+    try:
+        with pytest.warns(RuntimeWarning, match="Could not import settings package"):
+            discover_tasks()
+    finally:
+        utils._discover_tasks_impl.cache_clear()
+
+
+def test_discover_warns_on_import_failure(monkeypatch):
+    """A package whose tasks module fails to import yields a warning, not a crash."""
+    orig_import = utils.import_module
+
+    def fake_import(name):
+        if name.endswith(".tasks"):
+            raise ImportError("boom")
+        return orig_import(name)
+
+    monkeypatch.setattr(utils, "import_module", fake_import)
+
+    utils._discover_tasks_impl.cache_clear()
+    try:
+        with pytest.warns(RuntimeWarning, match="Failed to import tasks"):
+            discover_tasks()
+    finally:
+        utils._discover_tasks_impl.cache_clear()

--- a/tests/management/test_clear_stale_results.py
+++ b/tests/management/test_clear_stale_results.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
@@ -90,3 +91,13 @@ class TestClearStaleResults:
         remaining_tasks = TaskResult.objects.all()
         assert len(remaining_tasks) == 1
         assert remaining_tasks[0].task_id == recent_task.task_id
+
+    def test_clear_stale_results_delay_offloads_to_qstash(self):
+        """The --delay flag offloads the work via the task's delay()."""
+        with patch(
+            "django_qstash.results.tasks.clear_stale_results_task.delay"
+        ) as mock_delay:
+            call_command("clear_stale_results", "--no-input", "--delay")
+
+        mock_delay.assert_called_once()
+        assert mock_delay.call_args[1]["user_confirm"] is False

--- a/tests/results/test_clear_stale_results_task.py
+++ b/tests/results/test_clear_stale_results_task.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from io import StringIO
+from unittest.mock import patch
 
 import pytest
 from django.utils import timezone
@@ -221,3 +222,72 @@ class TestClearStaleResults:
         clear_stale_results_task(stdout=stdout)
 
         assert "No stale Django QStash task results found" in stdout.getvalue()
+
+    def test_skip_deletion_logs_without_stdout(
+        self, create_task_result, monkeypatch, caplog
+    ):
+        create_task_result("stale-task", age=timedelta(days=8))
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+
+        with caplog.at_level("INFO"):
+            clear_stale_results_task(user_confirm=True)
+
+        assert TaskResult.objects.count() == 1
+        assert "Skipping deletion" in caplog.text
+
+    def test_no_results_logs_without_stdout(self, caplog):
+        with caplog.at_level("INFO"):
+            clear_stale_results_task()
+        assert "No stale Django QStash task results found" in caplog.text
+
+    def test_delete_logs_without_stdout(self, create_task_result, caplog):
+        create_task_result("stale-task", age=timedelta(days=8))
+        with caplog.at_level("INFO"):
+            clear_stale_results_task()
+        assert TaskResult.objects.count() == 0
+        assert "Successfully deleted 1 stale results." in caplog.text
+
+    def test_delete_error_without_stdout(self, create_task_result, caplog):
+        create_task_result("stale-task", age=timedelta(days=8))
+
+        class MockQuerySet:
+            def delete(self):
+                raise Exception("Boom")
+
+            def exists(self):
+                return True
+
+            def count(self):
+                return 1
+
+            def exclude(self, **kwargs):
+                return self
+
+        with patch(
+            "django_qstash.results.models.TaskResult.objects.filter",
+            return_value=MockQuerySet(),
+        ):
+            with pytest.raises(Exception, match="Boom"):
+                clear_stale_results_task()
+
+        assert "Error deleting stale results: Boom" in caplog.text
+
+
+def test_clear_stale_results_model_not_installed(caplog):
+    """A missing results model raises LookupError after logging."""
+    with patch(
+        "django_qstash.results.tasks.apps.get_model", side_effect=LookupError("nope")
+    ):
+        with pytest.raises(LookupError):
+            clear_stale_results_task()
+    assert "Django QStash Results not installed" in caplog.text
+
+
+def test_clear_stale_results_model_not_installed_with_stdout():
+    stdout = StringIO()
+    with patch(
+        "django_qstash.results.tasks.apps.get_model", side_effect=LookupError("nope")
+    ):
+        with pytest.raises(LookupError):
+            clear_stale_results_task(stdout=stdout)
+    assert "Django QStash Results not installed" in stdout.getvalue()

--- a/tests/schedules/test_models.py
+++ b/tests/schedules/test_models.py
@@ -143,6 +143,28 @@ def test_did_just_pause(db):
     )  # Should be True with 3 minute window
 
 
+def test_did_just_resume_false_when_not_resumed(db):
+    """did_just_resume returns False when the schedule isn't in a resumed state."""
+    schedule = TaskSchedule.objects.create(
+        name="Not Resumed",
+        task="myapp.tasks.test_task",
+        is_active=False,
+    )
+    assert schedule.is_resumed is False
+    assert schedule.did_just_resume() is False
+
+
+def test_did_just_pause_false_when_not_paused(db):
+    """did_just_pause returns False when the schedule isn't in a paused state."""
+    schedule = TaskSchedule.objects.create(
+        name="Not Paused",
+        task="myapp.tasks.test_task",
+        is_active=True,
+    )
+    assert schedule.is_paused is False
+    assert schedule.did_just_pause() is False
+
+
 @pytest.mark.parametrize(
     "timeout,retries,expected_valid",
     [

--- a/tests/schedules/test_services.py
+++ b/tests/schedules/test_services.py
@@ -120,6 +120,74 @@ def test_get_task_schedule_from_qstash(task_schedule):
 
 
 @pytest.mark.django_db
+def test_sync_does_not_overwrite_existing_schedule_id(task_schedule):
+    """When a schedule_id already exists, it is not overwritten on sync."""
+    task_schedule.schedule_id = "existing-id"
+    task_schedule.save()
+    with patch(
+        "django_qstash.schedules.services.qstash_client.schedule.create",
+        return_value="new-id",
+    ):
+        sync_task_schedule_instance_to_qstash(task_schedule)
+    task_schedule.refresh_from_db()
+    assert task_schedule.schedule_id == "existing-id"
+
+
+@pytest.mark.django_db
+def test_sync_state_changes_noop(task_schedule):
+    """No resume/pause transition leaves QStash untouched."""
+    with (
+        patch(
+            "django_qstash.schedules.services.qstash_client.schedule.resume"
+        ) as mock_resume,
+        patch(
+            "django_qstash.schedules.services.qstash_client.schedule.pause"
+        ) as mock_pause,
+        patch.object(task_schedule, "did_just_resume", return_value=False),
+        patch.object(task_schedule, "did_just_pause", return_value=False),
+    ):
+        sync_state_changes(task_schedule)
+        mock_resume.assert_not_called()
+        mock_pause.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_sync_state_changes_resume_exception_swallowed(task_schedule):
+    with (
+        patch(
+            "django_qstash.schedules.services.qstash_client.schedule.resume",
+            side_effect=Exception("API Error"),
+        ),
+        patch.object(task_schedule, "did_just_resume", return_value=True),
+        patch.object(task_schedule, "did_just_pause", return_value=False),
+    ):
+        sync_state_changes(task_schedule)  # should not raise
+
+
+@pytest.mark.django_db
+def test_sync_state_changes_pause_exception_swallowed(task_schedule):
+    with (
+        patch(
+            "django_qstash.schedules.services.qstash_client.schedule.pause",
+            side_effect=Exception("API Error"),
+        ),
+        patch.object(task_schedule, "did_just_resume", return_value=False),
+        patch.object(task_schedule, "did_just_pause", return_value=True),
+    ):
+        sync_state_changes(task_schedule)  # should not raise
+
+
+@pytest.mark.django_db
+def test_get_task_schedule_falsy_response(task_schedule):
+    """A falsy (but non-error) response returns None."""
+    with patch(
+        "django_qstash.schedules.services.qstash_client.schedule.get",
+        return_value=None,
+    ):
+        assert get_task_schedule_from_qstash(task_schedule) is None
+
+
+@pytest.mark.django_db
 def test_delete_task_schedule_from_qstash(task_schedule):
     """Test deleting a schedule from QStash"""
     with patch(

--- a/tests/schedules/test_signals.py
+++ b/tests/schedules/test_signals.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from django_qstash.schedules import signals
+from django_qstash.schedules.models import TaskSchedule
+
+
+@pytest.mark.django_db
+def test_sync_receiver_delegates_to_service(task_schedule):
+    with patch(
+        "django_qstash.schedules.signals.services.sync_task_schedule_instance_to_qstash"
+    ) as mock_sync:
+        signals.sync_schedule_to_qstash_receiver(
+            TaskSchedule, task_schedule, created=True
+        )
+        mock_sync.assert_called_once_with(task_schedule)
+
+
+@pytest.mark.django_db
+def test_delete_receiver_delegates_to_service(task_schedule):
+    with patch(
+        "django_qstash.schedules.signals.services.delete_task_schedule_from_qstash"
+    ) as mock_delete:
+        signals.delete_schedule_from_qstash_receiver(TaskSchedule, task_schedule)
+        mock_delete.assert_called_once_with(task_schedule)

--- a/tests/schedules/test_validators.py
+++ b/tests/schedules/test_validators.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from django_qstash.schedules.exceptions import InvalidCronStringValidationError
+from django_qstash.schedules.exceptions import InvalidDurationStringValidationError
+from django_qstash.schedules.validators import validate_cron_expression
+from django_qstash.schedules.validators import validate_duration_string
+
+
+class TestValidateDurationString:
+    @pytest.mark.parametrize("value", ["60s", "5m", "2h", "7d"])
+    def test_valid(self, value):
+        validate_duration_string(value)  # should not raise
+
+    @pytest.mark.parametrize("value", ["60", "abc", "5x", ""])
+    def test_invalid_format(self, value):
+        with pytest.raises(InvalidDurationStringValidationError, match="Invalid"):
+            validate_duration_string(value)
+
+    @pytest.mark.parametrize("value", ["8d", "169h", "604801s"])
+    def test_too_long(self, value):
+        with pytest.raises(InvalidDurationStringValidationError, match="too long"):
+            validate_duration_string(value)
+
+
+class TestValidateCronExpression:
+    def test_valid(self):
+        validate_cron_expression("*/5 * * * *")  # should not raise
+
+    @pytest.mark.parametrize("value", ["* * * *", "* * * * * *", "*", ""])
+    def test_wrong_field_count(self, value):
+        with pytest.raises(InvalidCronStringValidationError, match="5 fields"):
+            validate_cron_expression(value)
+
+    def test_invalid_field_value(self):
+        with pytest.raises(InvalidCronStringValidationError):
+            validate_cron_expression("99 * * * *")

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -78,6 +78,53 @@ class TestValidateDomain:
             == "https://api.v1.staging.example.com"
         )
 
+    def test_missing_hostname_raises(self):
+        with pytest.raises(ImproperlyConfigured, match="must include a hostname"):
+            validate_domain("https://")
+
+    def test_urlparse_failure_raises(self):
+        with patch(
+            "django_qstash.callbacks.urlparse", side_effect=ValueError("bad url")
+        ):
+            with pytest.raises(
+                ImproperlyConfigured, match="Invalid DJANGO_QSTASH_DOMAIN"
+            ):
+                validate_domain("example.com")
+
+    def test_non_http_scheme_after_parse_raises(self):
+        from urllib.parse import ParseResult
+
+        fake = ParseResult(
+            scheme="ftp",
+            netloc="example.com",
+            path="",
+            params="",
+            query="",
+            fragment="",
+        )
+        with patch("django_qstash.callbacks.urlparse", return_value=fake):
+            with pytest.raises(ImproperlyConfigured, match="Invalid protocol"):
+                validate_domain("example.com")
+
+
+class TestGetCallbackUrlMisconfigured:
+    def test_no_domain_raises(self):
+        with patch("django_qstash.callbacks.DJANGO_QSTASH_DOMAIN", None):
+            with pytest.raises(
+                ImproperlyConfigured, match="DJANGO_QSTASH_DOMAIN is not set"
+            ):
+                get_callback_url()
+
+    def test_no_webhook_path_raises(self):
+        with (
+            patch("django_qstash.callbacks.DJANGO_QSTASH_DOMAIN", "example.com"),
+            patch("django_qstash.callbacks.DJANGO_QSTASH_WEBHOOK_PATH", None),
+        ):
+            with pytest.raises(
+                ImproperlyConfigured, match="DJANGO_QSTASH_WEBHOOK_PATH is not set"
+            ):
+                get_callback_url()
+
 
 @pytest.mark.parametrize(
     "domain,webhook_path,expected",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from django_qstash.client import init_qstash
+
+
+def test_init_qstash_no_url(monkeypatch):
+    """No QSTASH_URL -> plain client, no base_url override."""
+    monkeypatch.setattr("django_qstash.client.QSTASH_URL", None)
+    client = init_qstash()
+    assert client is not None
+
+
+def test_init_qstash_custom_url_warns(monkeypatch):
+    """A non-Upstash QSTASH_URL warns and sets base_url for dev use."""
+    monkeypatch.setattr("django_qstash.client.QSTASH_URL", "http://localhost:8080")
+    with pytest.warns(RuntimeWarning, match="development"):
+        client = init_qstash()
+    assert client is not None
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://foo.upstash.io",
+        "https://bar.upstash.cloud",
+        "https://baz.upstash.com",
+    ],
+)
+def test_init_qstash_upstash_url_no_warning(monkeypatch, recwarn, url):
+    """Known Upstash domains don't trigger the development warning."""
+    monkeypatch.setattr("django_qstash.client.QSTASH_URL", url)
+    client = init_qstash()
+    assert client is not None
+    assert not any("development" in str(w.message) for w in recwarn.list)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 from django.http import HttpRequest
 
+from django_qstash.db.models import TaskStatus
 from django_qstash.exceptions import PayloadError
 from django_qstash.exceptions import SignatureError
 from django_qstash.exceptions import TaskError
@@ -166,6 +167,52 @@ class TestQStashWebhook:
             result = webhook.execute_task(payload)
 
         assert result == "actual result"
+
+    def test_execute_task_plain_callable(self, webhook):
+        """A plain callable without actual_func is invoked directly."""
+
+        def plain(*args, **kwargs):
+            return "plain result"
+
+        payload = Mock(
+            function_path="test.path",
+            args=[],
+            kwargs={},
+            task_name="test.path",
+        )
+        with (
+            patch(
+                "django_qstash.handlers.discover_tasks",
+                return_value=["test.path"],
+            ),
+            patch("django_qstash.handlers.utils.import_string", return_value=plain),
+            patch("django_qstash.handlers._emit_signal"),
+        ):
+            result = webhook.execute_task(payload)
+
+        assert result == "plain result"
+
+    def test_handle_request_unexpected_error_stores_result(self, webhook):
+        """An unexpected error after the payload is parsed stores an INTERNAL_ERROR."""
+        request = Mock(spec=HttpRequest)
+        request.body = json.dumps(
+            {"function": "test_func", "module": "test_module", "args": [], "kwargs": {}}
+        ).encode()
+        request.headers = {"Upstash-Signature": "valid", "Upstash-Message-Id": "123"}
+        request.META = {"REMOTE_ADDR": "127.0.0.1"}
+        request.build_absolute_uri.return_value = "https://example.com"
+
+        with (
+            patch.object(webhook, "verify_signature"),
+            patch.object(webhook, "execute_task", side_effect=ValueError("kaboom")),
+            patch("django_qstash.handlers.store_task_result") as mock_store,
+        ):
+            response, status = webhook.handle_request(request)
+
+        assert status == 500
+        assert response["error_type"] == "InternalServerError"
+        mock_store.assert_called_once()
+        assert mock_store.call_args[1]["status"] == TaskStatus.INTERNAL_ERROR
 
 
 class TestEnsureHttps:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import builtins
+import json
+import logging
+
+from django_qstash.logging import JSONFormatter
+from django_qstash.logging import configure_structured_logging
+from django_qstash.logging import get_correlation_id
+
+
+def _make_record(**extra):
+    record = logging.LogRecord(
+        name="django_qstash.test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="message",
+        args=(),
+        exc_info=None,
+    )
+    for key, value in extra.items():
+        setattr(record, key, value)
+    return record
+
+
+def test_get_correlation_id_import_error(monkeypatch):
+    """If handlers can't be imported, correlation id falls back to ''."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "django_qstash.handlers":
+            raise ImportError("boom")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert get_correlation_id() == ""
+
+
+def test_format_includes_stack_info():
+    formatter = JSONFormatter()
+    record = _make_record(stack_info="Traceback stack here")
+    data = json.loads(formatter.format(record))
+    assert data["stack_info"] == "Traceback stack here"
+
+
+def test_format_non_serializable_extra_falls_back_to_str():
+    formatter = JSONFormatter()
+    sentinel = object()
+    record = _make_record(weird=sentinel)
+    data = json.loads(formatter.format(record))
+    assert data["weird"] == str(sentinel)
+
+
+def test_configure_structured_logging():
+    logger_name = "django_qstash_test_configure"
+    configure_structured_logging(logger_name)
+    logger = logging.getLogger(logger_name)
+    try:
+        assert len(logger.handlers) == 1
+        handler = logger.handlers[0]
+        assert isinstance(handler.formatter, JSONFormatter)
+        assert logger.level == logging.INFO
+    finally:
+        logger.handlers = []

--- a/tests/test_results_services.py
+++ b/tests/test_results_services.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from django_qstash.db.models import TaskStatus
+from django_qstash.results.services import function_result_to_dict
+from django_qstash.results.services import store_task_result
+
+
+class TestFunctionResultToDict:
+    def test_none_returns_none(self):
+        assert function_result_to_dict(None) is None
+
+    def test_dict_passthrough(self):
+        assert function_result_to_dict({"a": 1}) == {"a": 1}
+
+    def test_json_string_dict(self):
+        assert function_result_to_dict('{"a": 1}') == {"a": 1}
+
+    def test_json_string_non_dict_wrapped(self):
+        assert function_result_to_dict("[1, 2]") == {"result": [1, 2]}
+
+    def test_non_json_string_wrapped(self):
+        assert function_result_to_dict("hello") == {"result": "hello"}
+
+    def test_other_type_wrapped(self):
+        assert function_result_to_dict(42) == {"result": 42}
+
+
+@pytest.mark.django_db
+class TestStoreTaskResult:
+    def test_stores_valid_result(self):
+        from django_qstash.results.models import TaskResult
+
+        obj = store_task_result(
+            task_id="t1",
+            task_name="name",
+            status=TaskStatus.SUCCESS,
+            result={"x": 1},
+        )
+        assert obj is not None
+        assert obj.result == {"x": 1}
+        assert TaskResult.objects.filter(pk=obj.pk).exists()
+
+    def test_invalid_status_becomes_unknown(self):
+        obj = store_task_result(
+            task_id="t2",
+            task_name="name",
+            status="NOT-A-REAL-STATUS",
+        )
+        assert obj is not None
+        assert obj.status == TaskStatus.UNKNOWN
+
+
+def test_store_task_result_model_not_installed():
+    """When the results model isn't installed, store quietly returns None."""
+    with patch(
+        "django_qstash.results.services.apps.get_model", side_effect=LookupError
+    ):
+        result = store_task_result(
+            task_id="t",
+            task_name="name",
+            status=TaskStatus.SUCCESS,
+        )
+    assert result is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import pytest
 
-from django_qstash.utils import import_string, validate_task_payload
+from django_qstash.utils import import_string
+from django_qstash.utils import validate_task_payload
 
 
 def test_import_string():
@@ -47,3 +50,25 @@ def test_validate_task_payload():
     is_valid, message = validate_task_payload(invalid_payload)
     assert not is_valid
     assert "Args must be" in message
+
+    # Invalid kwargs type
+    invalid_payload = {
+        "function": "task_func",
+        "module": "my_app.tasks",
+        "args": [1, 2, 3],
+        "kwargs": ["not", "a", "dict"],
+    }
+    is_valid, message = validate_task_payload(invalid_payload)
+    assert not is_valid
+    assert "Kwargs must be a dictionary" in message
+
+    # Tuple args are accepted
+    is_valid, message = validate_task_payload(
+        {
+            "function": "task_func",
+            "module": "my_app.tasks",
+            "args": (1, 2),
+            "kwargs": {},
+        }
+    )
+    assert is_valid


### PR DESCRIPTION
Add targeted tests across client, results services/tasks, logging,
callbacks, app base, handlers, schedules (signals/services/models/
validators), discovery utils, utils, and the clear_stale_results
management command. Simplify a redundant elif in TaskSchedule.save
that was logically unreachable dead branching.

Coverage: 90% -> 100% (256 tests passing).
