### PR TITLE
Upgrade pre-commit hooks, deps, and CI actions; enforce pre-commit in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -154,7 +154,15 @@ jobs:
         run: uv run pre-commit run --all-files --show-diff-on-failure --color=always
         timeout-minutes: 8
         env:
+          # mypy is already covered by the typecheck job. The makemigrations
+          # hook imports the sample project's settings, which read these via
+          # python-decouple; supply the committed local-dev-only values so the
+          # migration check runs in CI too.
           SKIP: mypy
+          QSTASH_TOKEN: ci-dummy-token
+          QSTASH_CURRENT_SIGNING_KEY: ci-dummy-current
+          QSTASH_NEXT_SIGNING_KEY: ci-dummy-next
+          DJANGO_QSTASH_DOMAIN: http://localhost:8000
 
   release:
     needs: [coverage, typecheck, pre-commit]

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,15 +36,15 @@ jobs:
         - '3.14'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         cache-dependency-glob: tests/requirements/*.txt
@@ -58,7 +58,7 @@ jobs:
       timeout-minutes: 15
 
     - name: Upload coverage data
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: coverage-data-${{ matrix.python-version }}
         path: '${{ github.workspace }}/.coverage.*'
@@ -71,21 +71,21 @@ jobs:
     timeout-minutes: 10
     needs: tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv pip install --system coverage[toml]
         timeout-minutes: 5
 
       - name: Download data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: ${{ github.workspace }}
           pattern: coverage-data-*
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload HTML report
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: html-report
           path: htmlcov
@@ -112,21 +112,52 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Run mypy
         run: uv run mypy src/
         timeout-minutes: 5
 
+  pre-commit:
+    name: Pre-commit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # Runs every hook on all files so stale formatting (e.g. an outdated
+      # black) fails CI instead of silently drifting. mypy is skipped here
+      # because the typecheck job already runs it.
+      - name: Run pre-commit
+        run: uv run pre-commit run --all-files --show-diff-on-failure --color=always
+        timeout-minutes: 8
+        env:
+          SKIP: mypy
+
   release:
-    needs: [coverage, typecheck]
+    needs: [coverage, typecheck, pre-commit]
     if: success() && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -137,9 +168,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
 
       - name: Build
         run: uv build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_language_version:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -17,51 +17,51 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.5.0
+  rev: v2.25.1
   hooks:
   - id: pyproject-fmt
 - repo: https://github.com/tox-dev/tox-ini-fmt
-  rev: 1.4.1
+  rev: 1.7.1
   hooks:
   - id: tox-ini-fmt
 - repo: https://github.com/rstcheck/rstcheck
-  rev: v6.2.4
+  rev: v6.2.5
   hooks:
   - id: rstcheck
     additional_dependencies:
     - sphinx==6.1.3
     - tomli==2.0.1
 - repo: https://github.com/sphinx-contrib/sphinx-lint
-  rev: v1.0.0
+  rev: v1.0.2
   hooks:
   - id: sphinx-lint
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.19.0
+  rev: v3.21.2
   hooks:
   - id: pyupgrade
-    args: [--py39-plus]
+    args: [--py310-plus]
 - repo: https://github.com/adamchainz/django-upgrade
-  rev: 1.22.2
+  rev: 1.31.1
   hooks:
   - id: django-upgrade
     args: [--target-version, '4.2']
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.10.0
+  rev: 26.5.1
   hooks:
   - id: black
 - repo: https://github.com/adamchainz/blacken-docs
-  rev: 1.19.1
+  rev: 1.20.0
   hooks:
   - id: blacken-docs
     additional_dependencies:
-    - black==23.1.0
+    - black==26.5.1
 - repo: https://github.com/pycqa/isort
-  rev: 5.13.2
+  rev: 8.0.1
   hooks:
     - id: isort
       name: isort (python)
 - repo: https://github.com/PyCQA/flake8
-  rev: 7.1.1
+  rev: 7.3.0
   hooks:
   - id: flake8
     additional_dependencies:
@@ -70,7 +70,7 @@ repos:
     - flake8-logging
     - flake8-tidy-imports
 - repo: https://github.com/adamchainz/djade-pre-commit
-  rev: 1.3.2
+  rev: 1.9.0
   hooks:
   - id: djade
 - repo: local

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -49,8 +49,7 @@ def stashed_task(
     name: str | None = None,
     deduplicated: bool = False,
     **options: dict[str, Any],
-) -> QStashTask:
-    ...
+) -> QStashTask: ...
 ```
 
 #### Parameters
@@ -144,8 +143,7 @@ Immediately queue a task for background execution.
 #### Signature
 
 ```python
-def delay(self, *args, **kwargs) -> AsyncResult:
-    ...
+def delay(self, *args, **kwargs) -> AsyncResult: ...
 ```
 
 #### Parameters
@@ -186,8 +184,7 @@ def apply_async(
     kwargs: dict | None = None,
     countdown: int | None = None,
     **options: dict[str, Any],
-) -> AsyncResult:
-    ...
+) -> AsyncResult: ...
 ```
 
 #### Parameters
@@ -251,8 +248,7 @@ def apply(
     args: tuple | None = None,
     kwargs: dict | None = None,
     **options: dict[str, Any],
-) -> EagerResult:
-    ...
+) -> EagerResult: ...
 ```
 
 #### Parameters
@@ -381,8 +377,7 @@ def get(
     timeout: float | None = None,
     interval: float | None = None,
     propagate: bool = True,
-) -> Any:
-    ...
+) -> Any: ...
 ```
 
 Blocks until a terminal result is stored, polling the results backend every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
-
 dependencies = [
   "django>=4.2",
   "qstash>=3,<4",
@@ -56,80 +55,72 @@ dev = [
   "types-requests",
 ]
 
-[tool.setuptools.package-data]
-django_qstash = [ "py.typed" ]
+[tool.setuptools]
+package-data.django_qstash = [ "py.typed" ]
 
 [tool.isort]
-add_imports = [
-  "from __future__ import annotations",
-]
-force_single_line = true
 profile = "black"
+force_single_line = true
 src_paths = [
   ".",
   "example",
   "src",
 ]
+add_imports = [
+  "from __future__ import annotations",
+]
 
 [tool.pyproject-fmt]
 max_supported_python = "3.14"
 
-[tool.pytest.ini_options]
-addopts = """\
-    --strict-config
-    --strict-markers
-    --ds=tests.settings
-    """
-django_find_project = false
-xfail_strict = true
-
-[tool.coverage.run]
-branch = true
-parallel = true
-source = [
-  "django_qstash",
-]
-omit = [
-  "*/migrations/*",
-  "*/admin.py",
-  "tests/*",
-]
-
-[tool.coverage.paths]
-source = [
-  "src/django_qstash",
-  ".tox/*/lib/python*/site-packages/django_qstash",
-]
-
-[tool.coverage.report]
-show_missing = true
-
 [tool.mypy]
-plugins = [ "mypy_django_plugin.main" ]
+mypy_path = "src/"
+namespace_packages = false
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+warn_unreachable = true
 enable_error_code = [
   "ignore-without-code",
   "redundant-expr",
   "truthy-bool",
 ]
-mypy_path = "src/"
-namespace_packages = false
 strict = true
-warn_unreachable = true
-warn_return_any = true
-warn_redundant_casts = true
-warn_unused_ignores = true
+plugins = [ "mypy_django_plugin.main" ]
+overrides = [
+  { module = "tests.*", disallow_untyped_defs = false },
+  { module = "qstash.*", ignore_missing_imports = true }
+]
 show_error_codes = true
-
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_untyped_defs = false
-
-[[tool.mypy.overrides]]
-module = "qstash.*"
-ignore_missing_imports = true
 
 [tool.django-stubs]
 django_settings_module = "tests.settings"
+
+[tool.pytest]
+ini_options.addopts = """\
+    --strict-config
+    --strict-markers
+    --ds=tests.settings
+    """
+ini_options.xfail_strict = true
+ini_options.django_find_project = false
+
+[tool.coverage]
+run.branch = true
+run.omit = [
+  "*/admin.py",
+  "*/migrations/*",
+  "tests/*",
+]
+run.parallel = true
+run.source = [
+  "django_qstash",
+]
+paths.source = [
+  "src/django_qstash",
+  ".tox/*/lib/python*/site-packages/django_qstash",
+]
+report.show_missing = true
 
 [tool.rstcheck]
 ignore_directives = [

--- a/sample_project/manage.py
+++ b/sample_project/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 from __future__ import annotations
 
 import os

--- a/src/django_qstash/app/base.py
+++ b/src/django_qstash/app/base.py
@@ -5,11 +5,11 @@ import inspect
 import time
 import traceback as traceback_module
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 from datetime import timezone
 from functools import partial
 from typing import Any
-from typing import Callable
 from typing import Generic
 from typing import TypeVar
 from typing import overload

--- a/src/django_qstash/app/decorators.py
+++ b/src/django_qstash/app/decorators.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
-from typing import Callable
 from typing import TypeVar
 from typing import overload
 


### PR DESCRIPTION
## Why

cclauss flagged on #10 that black was still on a 2024 release (`24.10.0`), meaning pre-commit autoupdate was not working. Root cause: the `ci: autoupdate_schedule: monthly` block in `.pre-commit-config.yaml` only runs when the pre-commit.ci app is installed (it is not), and **no workflow ran pre-commit at all**, so every hook silently drifted and CI never noticed. Earlier fix attempts (#8, #10) were closed unmerged.

## What changed

**pre-commit hooks bumped to latest stable:**

| hook | from -> to |
|---|---|
| black | 24.10.0 -> 26.5.1 |
| blacken-docs | 1.19.1 -> 1.20.0 (inner `black` 23.1.0 -> 26.5.1) |
| pre-commit-hooks | v5.0.0 -> v6.0.0 |
| pyproject-fmt | v2.5.0 -> v2.25.1 |
| tox-ini-fmt | 1.4.1 -> 1.7.1 |
| rstcheck | v6.2.4 -> v6.2.5 |
| sphinx-lint | v1.0.0 -> v1.0.2 |
| pyupgrade | v3.19.0 -> v3.21.2 (`--py39-plus` -> `--py310-plus`) |
| django-upgrade | 1.22.2 -> 1.31.1 |
| isort | 5.13.2 -> 8.0.1 (stable, not the `9.0.0a3` prerelease autoupdate picked) |
| flake8 | 7.1.1 -> 7.3.0 |
| djade | 1.3.2 -> 1.9.0 |

**Auto-applied reformatting:** black 26 stable style (collapsed `...` stubs, blank line after module docstring) and pyupgrade moving `Callable` to `collections.abc`.

**GitHub Actions:** checkout v4->v5, setup-python v5->v6, setup-uv v4->v7, upload-artifact v4->v5, download-artifact v4->v6.

**New `Pre-commit` CI job:** runs every hook on all files (`--show-diff-on-failure`) so stale formatting fails CI instead of drifting. `mypy` is skipped (the `typecheck` job covers it); caches hook envs; both job and step have `timeout-minutes`. `release` now depends on it.

## Verification

- All 337 tests pass.
- `pre-commit run --all-files` is green (and green again with `SKIP=mypy`, exactly as CI runs it).

## Follow-up (not in this PR)

This stops formatting drift but does not auto-bump hook versions. To keep them current automatically, either install the pre-commit.ci app or add a scheduled `pre-commit autoupdate` workflow that opens a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)